### PR TITLE
Simplify find-generic-password call

### DIFF
--- a/openconnect.sh
+++ b/openconnect.sh
@@ -45,12 +45,12 @@ VPN_USERNAME="vpn_username@domain.tld#VPN_TUNNEL_OPTIONALLY"
 #      b.) Click on "login" keychain (top left corner)
 #      c.) Click on "Passwords" category (bottom left corner)
 #      d.) From the "File" menu, select -> "New Password Item..."
-#      e.) For "Keychain Item Name" and "Account Name" use the value for "VPN_HOST"
+#      e.) For "Keychain Item Name" and "Account Name" use the value for "VPN_HOST" and "VPN_USERNAME" respectively
 #      f.) For "Password" enter your VPN AnyConnect password.
 
 # This will retrieve that password securely at run time when you connect, and feed it to openconnect
 # No storing passwords unenin plain text files! :)
-GET_VPN_PASSWORD="security find-generic-password -g -a $VPN_HOST 2>&1 >/dev/null | cut -d'\"' -f2"
+GET_VPN_PASSWORD="security find-generic-password -wl $VPN_HOST"
 
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 # END-OF-USER-SETTINGS #


### PR DESCRIPTION
-w              Display the password(only) for the item found
-l label       Match label string
I personally use ${VPN_USERNAME}@${VPN_HOST} as a label, but this is probably a breaking change.